### PR TITLE
Rename dsd app from simple_deploy to django_simple_deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Changelog: dsd-<platformname>
 0.2 - Support for `--automate-all`
 ---
 
+### 0.2.1
+
+#### External changes
+
+- Updated to match core app name change from `simple_deploy` to `django-simple-deploy`.
+
+#### Internal changes
+
+- Minor naming changes to make project consistent with current names in core.
+
 ### 0.2.0
 
 #### External changes

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Deployment to CodeRed requires the following:
 
 ## Configuration-only deployment
 
-First, install `dsd-codered` and add `simple_deploy` to `INSTALLED_APPS` in *settings.py*:
+First, install `dsd-codered` and add `django_simple_deploy` to `INSTALLED_APPS` in *settings.py*:
 
 ```sh
 $ pip install dsd-codered
-# Add "simple_deploy" to INSTALLED_APPS in settings.py.
-$ git commit -am "Added simple_deploy to INSTALLED_APPS."
+# Add "django_simple_deploy" to INSTALLED_APPS in settings.py.
+$ git commit -am "Added django_simple_deploy to INSTALLED_APPS."
 ```
 
 When you install `dsd-codered`, it will install `django-simple-deploy` as a dependency.
@@ -48,18 +48,18 @@ $ cr deploy <codered-app-name>
 
 Here, `<codered-app-name>` is the name you chose when you created a new project in the CodeRed admin interface. The last line of output will show you the URL for your deployed project. You can also find this URL in your CodeRed admin interace.
 
-You can find a record of the deployment process in `simple_deploy_logs`. It contains most of the output you saw when running `deploy`.
+You can find a record of the deployment process in `dsd_logs/`. It contains most of the output you saw when running `deploy`.
 
 ## Automated deployment
 
 You can automate most of this process:
 
 - Create a Django project in the CodeRed admin interface. Choose Django, and set the database to Postgres.
-- Next, install `dsd-codered` and add `simple_deploy` to `INSTALLED_APPS` in *settings.py*:
+- Next, install `dsd-codered` and add `django_simple_deploy` to `INSTALLED_APPS` in *settings.py*:
 
 ```sh
 $ pip install dsd-codered
-# Add "simple_deploy" to INSTALLED_APPS in settings.py.
+# Add "django_simple_deploy" to INSTALLED_APPS in settings.py.
 ```
 
 Now, set an environment variable with your CodeRed API token and run `deploy` in the fully automated mode:

--- a/dsd_codered/__init__.py
+++ b/dsd_codered/__init__.py
@@ -1,2 +1,2 @@
-from .deploy import simple_deploy_get_plugin_config
-from .deploy import simple_deploy_deploy
+from .deploy import dsd_get_plugin_config
+from .deploy import dsd_deploy

--- a/dsd_codered/deploy.py
+++ b/dsd_codered/deploy.py
@@ -4,21 +4,21 @@ Notes:
 - ...
 """
 
-import simple_deploy
+import django_simple_deploy
 
 from dsd_codered.platform_deployer import PlatformDeployer
 from .plugin_config import PluginConfig
 
 
-@simple_deploy.hookimpl
-def simple_deploy_get_plugin_config():
+@django_simple_deploy.hookimpl
+def dsd_get_plugin_config():
     """Get platform-specific attributes needed by core."""
     plugin_config = PluginConfig()
     return plugin_config
 
 
-@simple_deploy.hookimpl
-def simple_deploy_deploy():
+@django_simple_deploy.hookimpl
+def dsd_deploy():
     """Carry out platform-specific deployment steps."""
     platform_deployer = PlatformDeployer()
     platform_deployer.deploy()

--- a/dsd_codered/deploy_messages.py
+++ b/dsd_codered/deploy_messages.py
@@ -69,7 +69,7 @@ def success_msg(log_output=""):
     if log_output:
         msg += dedent(
             f"""
-        - You can find a full record of this configuration in the simple_deploy_logs directory.
+        - You can find a full record of this configuration in the dsd_logs directory.
         """
         )
 

--- a/dsd_codered/deploy_messages.py
+++ b/dsd_codered/deploy_messages.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 
 confirm_automate_all = """
-The --automate-all flag means simple_deploy will:
+The --automate-all flag means the deploy command will:
 - Configure your project for deployment to CodeRed.
 - Commit all changes to your project that are necessary for deployment.
 - Push these changes to CodeRed.

--- a/dsd_codered/platform_deployer.py
+++ b/dsd_codered/platform_deployer.py
@@ -54,9 +54,9 @@ import requests
 
 from . import deploy_messages as platform_msgs
 
-from simple_deploy.management.commands.utils import plugin_utils
-from simple_deploy.management.commands.utils.plugin_utils import sd_config
-from simple_deploy.management.commands.utils.command_errors import (
+from django_simple_deploy.management.commands.utils import plugin_utils
+from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
+from django_simple_deploy.management.commands.utils.command_errors import (
     SimpleDeployCommandError,
 )
 

--- a/dsd_codered/platform_deployer.py
+++ b/dsd_codered/platform_deployer.py
@@ -57,7 +57,7 @@ from . import deploy_messages as platform_msgs
 from django_simple_deploy.management.commands.utils import plugin_utils
 from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
 from django_simple_deploy.management.commands.utils.command_errors import (
-    SimpleDeployCommandError,
+    DSDCommandError,
 )
 
 from . import utils as cr_utils
@@ -97,7 +97,7 @@ class PlatformDeployer:
         Returns:
             None
         Raises:
-            SimpleDeployCommandError: If we find any reason deployment won't work.
+            DSDCommandError: If we find any reason deployment won't work.
         """
         pass
 

--- a/dsd_codered/platform_deployer.py
+++ b/dsd_codered/platform_deployer.py
@@ -7,7 +7,7 @@ Add a new file to the user's project, without using a template:
 
     def _add_dockerignore(self):
         # Add a dockerignore file, based on user's local project environmnet.
-        path = sd_config.project_root / ".dockerignore"
+        path = dsd_config.project_root / ".dockerignore"
         dockerignore_str = self._build_dockerignore()
         plugin_utils.add_file(path, dockerignore_str)
 
@@ -17,12 +17,12 @@ Add a new file to the user's project, using a template:
         # Add a minimal dockerfile.
         template_path = self.templates_path / "dockerfile_example"
         context = {
-            "django_project_name": sd_config.local_project_name,
+            "django_project_name": dsd_config.local_project_name,
         }
         contents = plugin_utils.get_template_string(template_path, context)
 
         # Write file to project.
-        path = sd_config.project_root / "Dockerfile"
+        path = dsd_config.project_root / "Dockerfile"
         plugin_utils.add_file(path, contents)
 
 Modify user's settings file:
@@ -55,7 +55,7 @@ import requests
 from . import deploy_messages as platform_msgs
 
 from django_simple_deploy.management.commands.utils import plugin_utils
-from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
+from django_simple_deploy.management.commands.utils.plugin_utils import dsd_config
 from django_simple_deploy.management.commands.utils.command_errors import (
     DSDCommandError,
 )
@@ -110,7 +110,7 @@ class PlatformDeployer:
         prompt += "\n  If you haven't already done so, go to your CodeRed dashboard and create a site now."
         prompt += "\n\n  What's the name of the website project you created in the CodeRed dashboard? "
 
-        if not sd_config.unit_testing:
+        if not dsd_config.unit_testing:
             self.cr_project_name = plugin_utils.get_user_info(prompt)
         else:
             self.cr_project_name = "blog"
@@ -125,7 +125,7 @@ class PlatformDeployer:
         overrides.
         """
         # Add new settings dir, if it doesn't already exist.
-        path_settings_dir = sd_config.settings_path.parent / "settings"
+        path_settings_dir = dsd_config.settings_path.parent / "settings"
         if not path_settings_dir.exists():
             plugin_utils.write_output(
                 f"\nAdding new settings/ directory at {path_settings_dir}..."
@@ -135,7 +135,7 @@ class PlatformDeployer:
         # Copy settings file to base.py.
         path_settings_base = path_settings_dir / "base.py"
         plugin_utils.write_output(f"  Copying settings.py to {path_settings_base}.")
-        shutil.copy(sd_config.settings_path, path_settings_base)
+        shutil.copy(dsd_config.settings_path, path_settings_base)
 
         # Write prod settings. There's no custom data, so just copy the template file.
         path_settings_prod = path_settings_dir / "prod.py"
@@ -147,10 +147,10 @@ class PlatformDeployer:
 
         # Remove original settings.py file.
         plugin_utils.write_output(
-            f"  Deleting original settings file: {sd_config.settings_path}"
+            f"  Deleting original settings file: {dsd_config.settings_path}"
         )
-        sd_config.settings_path.unlink()
-        sd_config.settings_path = None
+        dsd_config.settings_path.unlink()
+        dsd_config.settings_path = None
 
     def _modify_managepy(self):
         """Update manage.py so it loads base settings, not prod.
@@ -162,7 +162,7 @@ class PlatformDeployer:
         dependent on this env var.
         """
         plugin_utils.write_output("Modifying manage.py to use local settings...")
-        path_managepy = sd_config.project_root / "manage.py"
+        path_managepy = dsd_config.project_root / "manage.py"
 
         # A template would be nicer, but I believe this approach is more resilient to
         # changes in manage.py across Django versions.
@@ -192,7 +192,7 @@ class PlatformDeployer:
         - ...
         """
         # Making this check here lets deploy() be cleaner.
-        if not sd_config.automate_all:
+        if not dsd_config.automate_all:
             return
 
         plugin_utils.commit_changes()
@@ -215,8 +215,8 @@ class PlatformDeployer:
 
         Describe ongoing approach of commit, push, migrate.
         """
-        if sd_config.automate_all:
+        if dsd_config.automate_all:
             msg = platform_msgs.success_msg_automate_all(self.deployed_url, self.cr_project_name)
         else:
-            msg = platform_msgs.success_msg(log_output=sd_config.log_output)
+            msg = platform_msgs.success_msg(log_output=dsd_config.log_output)
         plugin_utils.write_output(msg)

--- a/dsd_codered/plugin_config.py
+++ b/dsd_codered/plugin_config.py
@@ -6,7 +6,7 @@ from . import deploy_messages as platform_msgs
 class PluginConfig:
     """Class for managing attributes that need to be shared with core.
 
-    This is similar to the class SDConfig in core's sd_config.py.
+    This is similar to the class DSDConfig in core's dsd_config.py.
 
     This should future-proof plugins somewhat, in that if more information needs
     to be shared back to core, it can be added here without breaking changes to the

--- a/dsd_codered/utils.py
+++ b/dsd_codered/utils.py
@@ -7,7 +7,7 @@ from cr import api
 from django_simple_deploy.management.commands.utils.command_errors import (
     DSDCommandError,
 )
-from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
+from django_simple_deploy.management.commands.utils.plugin_utils import dsd_config
 
 
 def get_cr_project_status(cr_project_name, raw=False):
@@ -43,7 +43,7 @@ def validate_project_name(cr_project_name):
     Raises:
     - DSDCommandError: if project name is invalid.
     """
-    if sd_config.unit_testing:
+    if dsd_config.unit_testing:
         return
 
     try:

--- a/dsd_codered/utils.py
+++ b/dsd_codered/utils.py
@@ -5,7 +5,7 @@ import os
 from cr import api
 
 from django_simple_deploy.management.commands.utils.command_errors import (
-    SimpleDeployCommandError,
+    DSDCommandError,
 )
 from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
 
@@ -41,7 +41,7 @@ def validate_project_name(cr_project_name):
     Returns:
     - None: if project name is valid.
     Raises:
-    - SimpleDeployCommandError: if project name is invalid.
+    - DSDCommandError: if project name is invalid.
     """
     if sd_config.unit_testing:
         return
@@ -63,4 +63,4 @@ def validate_project_name(cr_project_name):
             msg += "\nIf you haven't created a project in the CodeRed admin panel yet, please"
             msg += "\n  do that and then run deploy again."
 
-        raise SimpleDeployCommandError(msg)
+        raise DSDCommandError(msg)

--- a/dsd_codered/utils.py
+++ b/dsd_codered/utils.py
@@ -4,10 +4,10 @@ import os
 
 from cr import api
 
-from simple_deploy.management.commands.utils.command_errors import (
+from django_simple_deploy.management.commands.utils.command_errors import (
     SimpleDeployCommandError,
 )
-from simple_deploy.management.commands.utils.plugin_utils import sd_config
+from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
 
 
 def get_cr_project_status(cr_project_name, raw=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dsd-codered"
-version = "0.2.0"
+version = "0.2.1"
 description = "A plugin for django-simple-deploy, supporting deployments to CodeRed."
 readme = "README.md"
 

--- a/tests/integration_tests/reference_files/.gitignore
+++ b/tests/integration_tests/reference_files/.gitignore
@@ -7,4 +7,4 @@ __pycache__/
 
 db.sqlite3
 
-simple_deploy_logs/
+dsd_logs/

--- a/tests/integration_tests/reference_files/settings_base.py
+++ b/tests/integration_tests/reference_files/settings_base.py
@@ -35,7 +35,7 @@ INSTALLED_APPS = [
     "blogs",
     "users",
     # Third party apps.
-    "simple_deploy",
+    "django_simple_deploy",
     "django_bootstrap5",
     # Default django apps.
     "django.contrib.admin",

--- a/tests/integration_tests/test_codered_config.py
+++ b/tests/integration_tests/test_codered_config.py
@@ -9,7 +9,7 @@ import pytest
 from tests.integration_tests.utils import it_helper_functions as hf
 from tests.integration_tests.conftest import (
     tmp_project,
-    run_simple_deploy,
+    run_dsd,
     reset_test_project,
     pkg_manager,
 )

--- a/tests/integration_tests/test_codered_config.py
+++ b/tests/integration_tests/test_codered_config.py
@@ -109,7 +109,7 @@ def test_managepy(tmp_project):
 
 def test_log_dir(tmp_project):
     """Test that the log directory exists, and contains an appropriate log file."""
-    log_path = Path(tmp_project / "simple_deploy_logs")
+    log_path = Path(tmp_project / "dsd_logs")
     assert log_path.exists()
 
     # There should be exactly two log files.
@@ -141,7 +141,7 @@ def test_log_dir(tmp_project):
     assert "INFO:   Using plugin: dsd_codered" in log_file_text
     assert "INFO: Local project name: blog" in log_file_text
     assert "INFO: git status --porcelain" in log_file_text
-    assert "INFO: ?? simple_deploy_logs/" in log_file_text
+    assert "INFO: ?? dsd_logs/" in log_file_text
 
     # Spot check for success messages.
     assert (
@@ -151,6 +151,6 @@ def test_log_dir(tmp_project):
     assert "INFO: To deploy your project, you will need to:" in log_file_text
 
     assert (
-        "INFO: - You can find a full record of this configuration in the simple_deploy_logs directory."
+        "INFO: - You can find a full record of this configuration in the dsd_logs directory."
         in log_file_text
     )


### PR DESCRIPTION
Also includes minor name changes to be more consistent with current usage.